### PR TITLE
Fix bs-url import

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,5 +1,5 @@
 {
-  "name": "bs-url",
+  "name": "@yamadayuki/bs-url",
   "version": "0.1.0",
   "sources": {
     "dir": "src",


### PR DESCRIPTION
Without this change, BuckleScript tries to import `bs-url`, which does not exist.

### Before
```
var URL = require("bs-url/src/URL.bs.js");
```

### After
```
var URL = require("@yamadayuki/bs-url/src/URL.bs.js");
```